### PR TITLE
Fix Painel de hidratação (salvar e alterar a meta)

### DIFF
--- a/lib/features/habits/presentation/pages/hydration_page.dart
+++ b/lib/features/habits/presentation/pages/hydration_page.dart
@@ -1,30 +1,55 @@
 import 'package:flutter/material.dart';
-import 'package:cinco_tigres_felizes/features/habits/models/hydration_model.dart';
+import 'package:provider/provider.dart';
+import '../../services/hydration_service.dart';
 
-class HidratacaoScreen extends StatefulWidget {
+class HidratacaoScreen extends StatelessWidget {
   const HidratacaoScreen({super.key});
 
-  @override
-  State<HidratacaoScreen> createState() => _HidratacaoScreenState();
-}
+  // Função para exibir a caixinha pop-up de edição
+  void _mostrarDialogEditarMeta(BuildContext context) {
+    final service = context.read<HidratacaoService>();
+    final TextEditingController controller = TextEditingController(
+      text: service.model.metaDiaria.toString(),
+    );
 
-class _HidratacaoScreenState extends State<HidratacaoScreen> {
-  // Dados iniciais
-  int _consumoAtual = 0;
-  final int _metaDiaria = 2000;
-
-  void _adicionarAgua(int quantidade) {
-    setState(() {
-      _consumoAtual += quantidade;
-    });
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Editar Meta Diária'),
+          content: TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              labelText: 'Nova meta em ml',
+              hintText: 'Ex: 2500',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final novaMeta = int.tryParse(controller.text);
+                if (novaMeta != null) {
+                  service.atualizarMeta(novaMeta);
+                }
+                Navigator.pop(context);
+              },
+              child: const Text('Salvar'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    final model = HidratacaoModel(
-      metaDiaria: _metaDiaria,
-      consumoAtual: _consumoAtual,
-    );
+    final service = context.watch<HidratacaoService>();
+    final model = service.model;
 
     return Scaffold(
       appBar: AppBar(
@@ -34,14 +59,12 @@ class _HidratacaoScreenState extends State<HidratacaoScreen> {
       body: Column(
         children: [
           const SizedBox(height: 40),
-          // A porcentagem
           Text(
             '${(model.porcentagem * 100).toInt()}%',
             style: const TextStyle(fontSize: 48, fontWeight: FontWeight.bold),
           ),
           const Text('da meta atingida'),
 
-          // Barra de progresso
           Padding(
             padding: const EdgeInsets.all(30.0),
             child: LinearProgressIndicator(
@@ -52,7 +75,30 @@ class _HidratacaoScreenState extends State<HidratacaoScreen> {
             ),
           ),
 
-          Text('Faltam ${model.restante} ml para atingir a meta'),
+          Text(
+            'Faltam ${model.restante} ml para atingir a meta de ${model.metaDiaria} ml',
+            style: const TextStyle(fontSize: 16),
+          ),
+
+          const SizedBox(height: 30), // Espaçamento antes do novo botão
+
+          // Botão para editar meta diária
+          ElevatedButton.icon(
+            onPressed: () => _mostrarDialogEditarMeta(context),
+            icon: const Icon(Icons.edit),
+            label: const Text(
+              'Editar meta diária',
+              style: TextStyle(fontSize: 16),
+            ),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blue, // Fundo azul
+              foregroundColor: Colors.white, // Texto e ícone brancos
+              padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 15),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
 
           const Spacer(),
 
@@ -63,24 +109,21 @@ class _HidratacaoScreenState extends State<HidratacaoScreen> {
                 titulo: 'Copo',
                 quantidade: 250,
                 icone: Icons.local_drink,
+                onPressed: () => context.read<HidratacaoService>().adicionarAgua(250),
               ),
               _botaoAgua(
                 titulo: 'Garrafa',
                 quantidade: 500,
                 icone: Icons.opacity,
+                onPressed: () => context.read<HidratacaoService>().adicionarAgua(500),
               ),
             ],
           ),
 
           const SizedBox(height: 20),
 
-          // Botão para resetar o contador
           TextButton.icon(
-            onPressed: () {
-              setState(() {
-                _consumoAtual = 0;
-              });
-            },
+            onPressed: () => context.read<HidratacaoService>().zerarDia(),
             icon: const Icon(Icons.refresh, color: Colors.red),
             label: const Text('Zerar Dia', style: TextStyle(color: Colors.red)),
           ),
@@ -95,9 +138,10 @@ class _HidratacaoScreenState extends State<HidratacaoScreen> {
     required String titulo,
     required int quantidade,
     required IconData icone,
+    required VoidCallback onPressed,
   }) {
     return ElevatedButton.icon(
-      onPressed: () => _adicionarAgua(quantidade),
+      onPressed: onPressed,
       icon: Icon(icone),
       label: Text('$titulo\n${quantidade}ml', textAlign: TextAlign.center),
       style: ElevatedButton.styleFrom(

--- a/lib/features/habits/services/hydration_service.dart
+++ b/lib/features/habits/services/hydration_service.dart
@@ -1,1 +1,30 @@
+import 'package:flutter/material.dart';
+import '../models/hydration_model.dart';
 
+class HidratacaoService extends ChangeNotifier {
+  int _consumoAtual = 0;
+  int _metaDiaria = 2000; 
+
+  HidratacaoModel get model => HidratacaoModel(
+        metaDiaria: _metaDiaria,
+        consumoAtual: _consumoAtual,
+      );
+
+  void adicionarAgua(int quantidade) {
+    _consumoAtual += quantidade;
+    notifyListeners();
+  }
+
+  void zerarDia() {
+    _consumoAtual = 0;
+    notifyListeners();
+  }
+
+  // Atualiza a meta diária e notifica a tela
+  void atualizarMeta(int novaMeta) {
+    if (novaMeta > 0) { 
+      _metaDiaria = novaMeta;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:cinco_tigres_felizes/features/access/presentation/pages/home_page.dart';
+import 'package:provider/provider.dart';
+import 'features/habits/services/hydration_service.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    // Envelopamos o app no MultiProvider
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => HidratacaoService()),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -152,6 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -200,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.5.5
+  provider: ^6.1.5+1
 
 dev_dependencies:
   flutter_test:

--- a/test/screens/hidratacao_screen_test.dart
+++ b/test/screens/hidratacao_screen_test.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cinco_tigres_felizes/features/habits/presentation/pages/hydration_page.dart';
-
+import 'package:provider/provider.dart'; 
+import 'package:cinco_tigres_felizes/features/habits/services/hydration_service.dart';
 void main() {
   testWidgets('Deve exibir a meta inicial e porcentagem zero', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(const MaterialApp(home: HidratacaoScreen()));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => HidratacaoService(),
+          child: const HidratacaoScreen(),
+        ),
+      ),
+    );
 
     // Verifica se encontra o texto de 0%
     expect(find.text('0%'), findsOneWidget);
 
-    // Em vez de procurar a frase inteira, procuramos apenas se o número 2000 aparece
+    // Verifica se o número 2000 (meta padrão) aparece
     expect(find.textContaining('2000'), findsOneWidget);
 
     // Verifica se os botões existem pelo texto simples


### PR DESCRIPTION
**O que foi modificado:**
- Ao editar o progresso da meta de água, adicionando os mL já ingeridos, o processo era perdido após retornar para a tela principal.
- O arquivo `hydration_service.dart` foi implementado para cuidar dessa lógica, para que o progresso não seja instanciado apenas localmente.
- Além disso, foi adicionado a funcionalidade de editar e adaptar a meta de hidratação