### PR TITLE
[Fix] Mudar lógica do contador da streak

### DIFF
--- a/lib/features/habits/models/habits_model.dart
+++ b/lib/features/habits/models/habits_model.dart
@@ -112,9 +112,21 @@ class HabitoModel {
     final hoje = DateTime.now();
     final hojeNormalizado = DateTime(hoje.year, hoje.month, hoje.day);
 
-    if (!estaConcluidoEm(hojeNormalizado)) return 0;
+    // Se hoje está completo, streak inclui hoje
+    if (estaConcluidoEm(hojeNormalizado)) {
+      int streak = 1;
+      var data = hojeNormalizado.subtract(const Duration(days: 1));
 
-    int streak = 1;
+      while (estaConcluidoEm(data)) {
+        streak++;
+        data = data.subtract(const Duration(days: 1));
+      }
+
+      return streak;
+    }
+    
+    // Se hoje NÃO está completo, streak vai até ontem
+    int streak = 0;
     var data = hojeNormalizado.subtract(const Duration(days: 1));
 
     while (estaConcluidoEm(data)) {
@@ -132,7 +144,12 @@ class HabitoModel {
     final hoje = DateTime.now();
     final hojeNormalizado = DateTime(hoje.year, hoje.month, hoje.day);
     final dataNormalizada = DateTime(data.year, data.month, data.day);
-    final inicioStreak = hojeNormalizado.subtract(Duration(days: streak - 1));
+    
+    // Se hoje está completo, streak inclui hoje
+    // Se hoje não está completo, streak vai até ontem
+    final inicioStreak = estaConcluidoEm(hojeNormalizado)
+        ? hojeNormalizado.subtract(Duration(days: streak - 1))
+        : hojeNormalizado.subtract(Duration(days: streak));
 
     return !dataNormalizada.isBefore(inicioStreak) &&
         !dataNormalizada.isAfter(hojeNormalizado) &&

--- a/test/features/habits/models/habitos_model_test.dart
+++ b/test/features/habits/models/habitos_model_test.dart
@@ -168,7 +168,7 @@ void main() {
       expect(habito.calcularStreak(), equals(1));
     });
 
-    test('vezesPorDia incompleto hoje retorna 0 mesmo com dias anteriores', () {
+    test('vezesPorDia incompleto hoje retorna streak até ontem', () {
       final d = hoje();
       final historico = <String, int>{
         chave(d): 1, // apenas 1 de 3
@@ -183,7 +183,7 @@ void main() {
         historico: historico,
       );
 
-      expect(habito.calcularStreak(), equals(0));
+      expect(habito.calcularStreak(), equals(2));
     });
 
     test('streak longa com quebra no meio retorna até a quebra', () {
@@ -206,7 +206,7 @@ void main() {
       expect(habito.calcularStreak(), equals(4));
     });
 
-    test('hoje vazio com dias antigos completos retorna 0', () {
+    test('hoje vazio com dias antigos completos retorna streak até ontem', () {
       final d = hoje();
       final historico = <String, int>{
         chave(d.subtract(const Duration(days: 1))): 1,
@@ -220,7 +220,7 @@ void main() {
         historico: historico,
       );
 
-      expect(habito.calcularStreak(), equals(0));
+      expect(habito.calcularStreak(), equals(3));
     });
   });
 
@@ -328,6 +328,40 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    test('todos os dias da streak até ontem retornam true quando hoje incompleto', () {
+      final d = hoje();
+      // Streak de 5 dias até ontem (hoje não completo)
+      final historico = <String, int>{
+        chave(d.subtract(const Duration(days: 1))): 1, // ontem
+        chave(d.subtract(const Duration(days: 2))): 1,
+        chave(d.subtract(const Duration(days: 3))): 1,
+        chave(d.subtract(const Duration(days: 4))): 1,
+        chave(d.subtract(const Duration(days: 5))): 1,
+      };
+      final habito = HabitoModel(
+        id: '1',
+        nome: 'Teste',
+        tipo: TipoFrequenciaHabito.diario,
+        historico: historico,
+      );
+
+      // streak deve ser 5 (até ontem)
+      expect(habito.calcularStreak(), equals(5));
+
+      // Todos os dias da streak devem retornar true
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 1))), isTrue);
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 2))), isTrue);
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 3))), isTrue);
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 4))), isTrue);
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 5))), isTrue);
+
+      // Dia anterior à streak deve retornar false
+      expect(habito.estaNaStreakAtual(d.subtract(const Duration(days: 6))), isFalse);
+      
+      // Hoje deve retornar false (não está na streak)
+      expect(habito.estaNaStreakAtual(d), isFalse);
     });
   });
 


### PR DESCRIPTION
A atual lógica do contador de streaks não havia ficado muito agradável para o usuário. Caso ele tenha uma streak de 5 dias ontem, hoje, enquanto o usuário não completar a meta do dia, parece que ele perdeu sua streak. Por isso, mudamos a lógica para que hoje o contador de streak mostre a quantidade até ontem e atualize caso a meta de hoje seja concluida, ou, caso não seja concluida, zere a streak amanhã.