### PR TITLE
[refactor] renomeia módulo de gamificação para achievement

### DIFF
--- a/lib/features/achievements/presentation/pages/gallery_page.dart
+++ b/lib/features/achievements/presentation/pages/gallery_page.dart
@@ -8,7 +8,7 @@ class AchievementsGalleryPage extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
-    final gamification = Provider.of<AchievementsProvider>(context);
+    final achievement = Provider.of<AchievementsProvider>(context);
     
     return Scaffold(
       appBar: AppBar(title: const Text('Minhas Conquistas')),
@@ -20,9 +20,9 @@ class AchievementsGalleryPage extends StatelessWidget {
           crossAxisSpacing: 16,
           mainAxisSpacing: 16,
         ),
-        itemCount: gamification.badges.length,
+        itemCount: achievement.badges.length,
         itemBuilder: (context, index) {
-          final badge = gamification.badges[index];
+          final badge = achievement.badges[index];
           
           return Card(
             color: badge.isDesbloqueado ? Colors.white : Colors.grey.shade200,

--- a/lib/features/achievements/providers/achievements_provider.dart
+++ b/lib/features/achievements/providers/achievements_provider.dart
@@ -5,13 +5,13 @@ import '../services/achievements_service.dart';
 
 class AchievementsProvider extends ChangeNotifier {
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey;
-  final GamificationService _service;
+  final AchievementsService _service;
 
   // Injeção do service para permitir testes
   AchievementsProvider(
     this.scaffoldMessengerKey, {
-    GamificationService? service,
-  }) : _service = service ?? GamificationService() {
+    AchievementsService? service,
+  }) : _service = service ?? AchievementsService() {
     _carregarDoBanco(); 
   }
 

--- a/lib/features/achievements/services/achievements_service.dart
+++ b/lib/features/achievements/services/achievements_service.dart
@@ -2,12 +2,12 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/badge_model.dart';
 
-class GamificationService {
+class AchievementsService {
   final FirebaseFirestore _db;
   final FirebaseAuth _auth;
 
   // Permite injetar mocks nos testes, mas usa a instância padrão em produção
-  GamificationService({
+  AchievementsService({
     FirebaseFirestore? firestore,
     FirebaseAuth? auth,
   })  : _db = firestore ?? FirebaseFirestore.instance,
@@ -22,7 +22,7 @@ class GamificationService {
     final snapshot = await _db
         .collection('users')
         .doc(_userId)
-        .collection('conquistas')
+        .collection('achievements')
         .get();
 
     final Map<String, DateTime> conquistas = {};
@@ -43,7 +43,7 @@ class GamificationService {
     await _db
         .collection('users')
         .doc(_userId)
-        .collection('conquistas')
+        .collection('achievements')
         .doc(badge.id)
         .set({
       'desbloqueadoEm': Timestamp.fromDate(badge.desbloqueadoEm!),

--- a/test/features/achievements/providers/achievements_provider_test.dart
+++ b/test/features/achievements/providers/achievements_provider_test.dart
@@ -30,16 +30,16 @@ HabitoModel criarHabitoComStreak(int diasConsecutivos) {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('GamificationProvider - avaliarConquistas', () {
+  group('AchievementsProvider - avaliarConquistas', () {
     late FakeFirebaseFirestore firestore;
     late MockFirebaseAuth auth;
-    late GamificationService service;
+    late AchievementsService service;
     late GlobalKey<ScaffoldMessengerState> scaffoldKey;
     
     setUp(() {
       firestore = FakeFirebaseFirestore();
       auth = MockFirebaseAuth(signedIn: true, mockUser: MockUser(uid: 'user-1'));
-      service = GamificationService(firestore: firestore, auth: auth);
+      service = AchievementsService(firestore: firestore, auth: auth);
       scaffoldKey = GlobalKey<ScaffoldMessengerState>();
     });
 
@@ -79,7 +79,7 @@ void main() {
 
     test('NÃO desbloqueia selo que já está desbloqueado', () async {
       // Pré-populando o banco falso para simular que o usuário JÁ TEM o selo
-      await firestore.collection('users').doc('user-1').collection('conquistas').doc('badge_3_dias').set({
+      await firestore.collection('users').doc('user-1').collection('achievements').doc('badge_3_dias').set({
         'desbloqueadoEm': Timestamp.fromDate(DateTime(2025, 1, 1)),
       });
 

--- a/test/features/achievements/services/achievements_service_test.dart
+++ b/test/features/achievements/services/achievements_service_test.dart
@@ -5,11 +5,11 @@ import 'package:cinco_tigres_felizes/features/achievements/models/badge_model.da
 import 'package:cinco_tigres_felizes/features/achievements/services/achievements_service.dart';
 
 void main() {
-  group('GamificationService', () {
+  group('AchievementsService', () {
     test('carregarConquistasDesbloqueadas retorna mapa vazio se não houver conquistas', () async {
       final firestore = FakeFirebaseFirestore();
       final auth = MockFirebaseAuth(signedIn: true, mockUser: MockUser(uid: 'user-1'));
-      final service = GamificationService(firestore: firestore, auth: auth);
+      final service = AchievementsService(firestore: firestore, auth: auth);
 
       final conquistas = await service.carregarConquistasDesbloqueadas();
 
@@ -19,7 +19,7 @@ void main() {
     test('salvarConquista e carregarConquistasDesbloqueadas funcionam corretamente', () async {
       final firestore = FakeFirebaseFirestore();
       final auth = MockFirebaseAuth(signedIn: true, mockUser: MockUser(uid: 'user-1'));
-      final service = GamificationService(firestore: firestore, auth: auth);
+      final service = AchievementsService(firestore: firestore, auth: auth);
 
       final dataDesbloqueio = DateTime(2026, 10, 10);
       final badge = BadgeModel(


### PR DESCRIPTION
## Resumo
Refatoração estrutural do módulo de conquistas, alterando a nomenclatura de `gamification` para `achievements`.

## Contexto e Motivação
A gamificação é um conceito amplo que pode abranger diversas mecânicas (pontuações, rankings, níveis). Para manter o princípio de Responsabilidade Única (Single Responsibility) e evitar ambiguidades futuras, limitamos o escopo deste módulo especificamente às conquistas. 
Além disso, adotamos o termo padrão (`achievements`) para manter a consistência do código, que já utiliza o inglês para a nomeação de pastas, classes e variáveis.